### PR TITLE
Fix#13, Remove PageRun block and add wo directives for sidenavbar and codeblock

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <base href="/summernote">
   <meta charset="utf-8">
   <title>Summernote - Super Simple WYSIWYG editor on Bootstrap</title>
   <meta name="description" content="Super Simple WYSIWYG Editor on Bootstrap">
@@ -19,13 +18,27 @@
   <script src="bower_components/bootstrap/dist/js/bootstrap.js"></script>
   <link href="bower_components/fontawesome/css/font-awesome.css" rel="stylesheet">
 
+  <!-- codemirror -->
+  <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/3.20.0/codemirror.min.css" />
+  <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/3.20.0/theme/monokai.min.css" />
+  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/3.20.0/codemirror.min.js"></script>
+  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/3.20.0/mode/xml/xml.min.js"></script>
+  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/2.36.0/formatting.min.js"></script>
+
+  <!-- highlight -->
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/7.3/styles/tomorrow.min.css"/>
+  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/7.3/highlight.min.js"></script>
+
   <!-- add summernote -->
   <link href="bower_components/summernote/dist/summernote.css" rel="stylesheet">
   <script src="bower_components/summernote/dist/summernote.js"></script>
 
   <!-- angular -->
   <script src="bower_components/angular/angular.js"></script>
-  <script src="bower_components/angular-route/angular-route.js"></script>
+  <script src="bower_components/angular-ui-router/release/angular-ui-router.min.js"></script>
+
+  <!-- language ko-KR -->
+  <script src="bower_components/summernote/lang/summernote-ko-KR.js"></script>
 
   <script src="js/app.js"></script>
   <link href="css/page.css" rel="stylesheet">
@@ -41,23 +54,24 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="./"><i class="fa fa-sun-o"></i> Summernote</a>
+      <a class="navbar-brand" ui-sref="app.home"><i class="fa fa-sun-o"></i> Summernote</a>
     </div>
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse navbar-ex1-collapse">
       <ul class="nav navbar-nav">
-        <li><a href="features">Features</a></li>
-        <li><a href="example">Example</a></li>
-        <li><a href="history">History</a></li>
-        <li><a href="about">About</a></li>
+        <li><a ui-sref="app.gettingstarted">Getting started</a></li>
+        <li><a ui-sref="app.deepdive">Deep dive</a></li>
+        <li><a ui-sref="app.example">Example</a></li>
+        <li><a ui-sref="app.team">Team</a></li>
+        <li><a href="/jsduck/" target="_blank">API Docs&nbsp; <i class="fa fa-external-link" style="font-size:12px"></i></a></li>
       </ul>
     </div>
   </div>
 </div>
-<div ng-view></div>
+<div ui-view></div>
 <footer class="footer">
   <div class="container">
-    <p><i class="fa fa-sun-o"></i> Summernote v0.6 · Created and Maintained by <a href="https://twitter.com/hackerwins">Alan</a></p>
+    <p><i class="fa fa-sun-o"></i> Summernote v0.6 · Created and Maintained by <a href="https://github.com/summernote">Summernote team</a>.</p>
     <p>Based on <a href="http://twitter.github.io/bootstrap/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Icons from <a href="http://fontawesome.io/">Font Awesome</a>. Theme from <a href="http://bootswatch.com">bootswatch</a>.</p>
     <p>Summernote distributed under the MIT license.</p>
     <p></p>
@@ -71,7 +85,6 @@
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
   ga('create', 'UA-42438082-1', 'github.com');
-  ga('send', 'pageview');
 </script>
 </body>
 </html>

--- a/html/deep-dive.html
+++ b/html/deep-dive.html
@@ -5,7 +5,7 @@
 <div class="container">
   <div class="row">
     <div class="col-md-3">
-      <div class="bs-page-sidebar" role="complementary">
+      <div class="bs-page-sidebar" side-navbar role="complementary">
         <ul class="nav">
           <li>
             <a data-target="#api" ng-click="scrollTo('api')">API</a>

--- a/html/example.html
+++ b/html/example.html
@@ -6,7 +6,7 @@
 
   <div class="row">
     <div class="col-md-3">
-      <div class="bs-page-sidebar" role="complementary">
+      <div class="bs-page-sidebar" side-navbar role="complementary">
         <ul class="nav">
           <li><a data-target="#multiple" ng-click="scrollTo('multiple')">Multiple Editor</a></li>
           <li><a data-target="#click2edit" ng-click="scrollTo('click2edit')">Click to Edit</a></li>

--- a/js/app.js
+++ b/js/app.js
@@ -4,8 +4,8 @@ angular
   ])
   .config(PageConfgig)
   .controller('PageController', PageController)
-  .run(PageRun);
-
+  .directive('sideNavbar', sideNavbarDirective)
+  .directive('code', codeDirective);
 
 PageConfgig.$inject = ['$urlRouterProvider', '$urlMatcherFactoryProvider', '$stateProvider'];
 
@@ -79,9 +79,6 @@ function PageConfgig($urlRouterProvider,  $urlMatcherFactoryProvider, $stateProv
 PageController.$inject = ['$scope', '$location', '$anchorScroll'];
 
 function PageController($scope, $location, $anchorScroll) {
-  var $body = $(document.body);
-  var $navbar = $('.navbar');
-
   $scope.$on('$viewContentLoaded', function (event) {
     window.scrollTo(0, 0);
     ga('send', 'pageview', { page: $location.url() });
@@ -93,13 +90,20 @@ function PageController($scope, $location, $anchorScroll) {
   };
 }
 
-PageRun.$inject = ['$rootScope'];
+sideNavbarDirective.$inject = [];
 
-function PageRun($rootScope) {
-  $rootScope.$on('$stateChangeSuccess', function () {
-    $('.navbar-collapse').collapse('hide');
+function sideNavbarDirective() {
+  return {
+    replace: false,
+    restrict: 'A',
+    link: PostLink
+  };
 
-    var $sidebar = $('.bs-page-sidebar');
+  function PostLink(scope, element, attr) {
+    var $sidebar = element;
+    var $body = $(document.body);
+    var $navbar = $('.navbar');
+
     if ($sidebar.length) {
       $body.scrollspy({
         target: '.bs-page-sidebar',
@@ -118,9 +122,21 @@ function PageRun($rootScope) {
         } 
       });
     }
+  }
+}
 
-    $('pre code').each(function(i, block) {
-      hljs.highlightBlock(block);
-    });
-  });
+codeDirective.$inject = [];
+
+function codeDirective() {
+  return {
+    replace: false,
+    restrict: 'E',
+    link: PostLink
+  };
+
+  function PostLink(scope, element, attr) {
+    if($(element).parent().prop('tagName') === 'PRE') {
+      $(element).html(hljs.highlightAuto($(element).text(), attr.class).value);
+    }
+  }
 }


### PR DESCRIPTION
Fix ReferenceError on Deep dive and Example Menu

- Remove PageRun block that exchange directives as follows:
 * sideNavbarDirective
 * codeDirective

- Add two directives for sidenavbar and codeblock.
  Why? Recommend - All DOM manipulation should be done inside directives
  Reference: http://google.github.io/styleguide/angularjs-google-style.html#directives

![image](https://cloud.githubusercontent.com/assets/1558742/8681412/2e634778-2aa2-11e5-9395-59a4642f9165.png)
