### PR TITLE
Fix typo 'libries' to 'libraries'

### DIFF
--- a/html/example.html
+++ b/html/example.html
@@ -56,7 +56,7 @@
         <h2 id="codemirror">CodeMirror as Codeview</h2>
         <p>If you include a <code>CodeMirror</code> on a page, you can use CodeMirror to Codeview.</p>
         <p>Include jQuery, Bootstrap, font-awesome and <b>CodeMirror</b> with summernote.</p>
-        <pre><code class="xml">&lt;!-- include libries(jQuery, bootstrap, fontawesome) --&gt;
+        <pre><code class="xml">&lt;!-- include libraries(jQuery, bootstrap, fontawesome) --&gt;
 &lt;script src="//code.jquery.com/jquery-1.9.1.min.js"&gt;&lt;/script&gt; 
 &lt;link href="//netdna.bootstrapcdn.com/bootstrap/3.0.1/css/bootstrap.min.css"&gt; 
 &lt;script src="//netdna.bootstrapcdn.com/bootstrap/3.0.1/js/bootstrap.min.js"&gt;&lt;/script&gt; 

--- a/html/getting-started.html
+++ b/html/getting-started.html
@@ -79,7 +79,7 @@
         <h3 id="installation-include">01. Include js/css</h3>
         <p>Summernote uses open source libraries(jQuery, Bootstrap, font-awesome).</p>
         <p>Include the Following code in your HTML <code>&lt;HTML&gt;</code> tag</p>
-        <pre><code class="xml">&lt;!-- include libries(jQuery, bootstrap, fontawesome) --&gt;
+        <pre><code class="xml">&lt;!-- include libraries(jQuery, bootstrap, fontawesome) --&gt;
 &lt;script src="//code.jquery.com/jquery-1.9.1.min.js"&gt;&lt;/script&gt; 
 &lt;link href="//netdna.bootstrapcdn.com/bootstrap/3.0.1/css/bootstrap.min.css" rel="stylesheet"&gt; 
 &lt;script src="//netdna.bootstrapcdn.com/bootstrap/3.0.1/js/bootstrap.min.js"&gt;&lt;/script&gt; 
@@ -146,7 +146,7 @@
         <h2 id="i18n">I18n Support</h2>
         <h3 id="i18n-language">Language</h3>
         <p>Include libraries with lang file. eg) <code>summernote-ko-KR.js</code></p>
-        <pre><code class="xml">&lt;!-- include libries(jQuery, bootstrap, fontawesome) --&gt;
+        <pre><code class="xml">&lt;!-- include libraries(jQuery, bootstrap, fontawesome) --&gt;
 &lt;script src="//code.jquery.com/jquery-1.9.1.min.js"&gt;&lt;/script&gt; 
 &lt;link href="//netdna.bootstrapcdn.com/bootstrap/3.0.1/css/bootstrap.min.css"&gt; 
 &lt;script src="//netdna.bootstrapcdn.com/bootstrap/3.0.1/js/bootstrap.min.js"&gt;&lt;/script&gt; 

--- a/html/plugin.html
+++ b/html/plugin.html
@@ -76,7 +76,7 @@ var save = function() {
         <h2 id="codemirror">CodeMirror as Codeview</h2>
         <p>If you include a <code>CodeMirror</code> on a page, you can use CodeMirror to Codeview.</p>
         <p>Include jQuery, Bootstrap, font-awesome and <b>CodeMirror</b> with summernote.</p>
-        <pre><code class="xml">&lt;!-- include libries(jQuery, bootstrap, fontawesome) --&gt;
+        <pre><code class="xml">&lt;!-- include libraries(jQuery, bootstrap, fontawesome) --&gt;
 &lt;script src="//code.jquery.com/jquery-1.9.1.min.js"&gt;&lt;/script&gt; 
 &lt;link href="//netdna.bootstrapcdn.com/bootstrap/3.0.1/css/bootstrap.min.css"&gt; 
 &lt;script src="//netdna.bootstrapcdn.com/bootstrap/3.0.1/js/bootstrap.min.js"&gt;&lt;/script&gt; 


### PR DESCRIPTION
fix typo on example.html, plugin.html and getting-started.html.