### PR TITLE
Change "newWindow" to "isNewWindow" for createLink docs on Deep Dive page

### DIFF
--- a/01-deep-dive.md
+++ b/01-deep-dive.md
@@ -446,11 +446,11 @@ Create link and unlink
 {% highlight javascript %}
 // @param {String} text - link text
 // @param {String} url - link url
-// @param {Boolean} newWindow - whether link's target is new window or not
+// @param {Boolean} isNewWindow - whether link's target is new window or not
 $('#summernote').summernote('createLink', {
   text: 'This is the Summernote's Official Site',
   url: 'http://summernote.org',
-  newWindow: true
+  isNewWindow: true
 });
 
 $('#summernote').summernote('unlink');


### PR DESCRIPTION
#### What does this PR do?
- Fixes `newWindow` param definition to `isNewWindow` for createLink docs on Deep Dive page, reflecting the actual attribute used in `src/js/base/module/Editor.js`.
#### Where should the reviewer start?
- `01-deep-dive.md`
#### What are the relevant tickets?

[#1728](https://github.com/summernote/summernote/issues/1728)
