### PR TITLE
Fix syntax error in createLink example

### DIFF
--- a/01-deep-dive.md
+++ b/01-deep-dive.md
@@ -425,7 +425,7 @@ Create link and unlink.
 // @param {String} url - link url
 // @param {Boolean} isNewWindow - whether link's target is new window or not
 $('#summernote').summernote('createLink', {
-  text: 'This is the Summernote's Official Site',
+  text: "This is the Summernote's Official Site",
   url: 'http://summernote.org',
   isNewWindow: true
 });


### PR DESCRIPTION
There is an error in '''createLink''' example because the sentence include a simple quote character ('). I fixed it by replacing the simple quotes to double quotes around the string.

There are others ways to fix the example like using \' or changing the sentence to remove the quote. I can change the fix if you want.