### PR TITLE
Add sub-section 'Custom line heights'

### DIFF
--- a/01-deep-dive.md
+++ b/01-deep-dive.md
@@ -163,6 +163,15 @@ $('#summernote').summernote({
 });
 {% endhighlight %}
 
+### Custom line heights
+You can override the default list and specify a custom one.
+
+{% highlight javascript %}
+$('#summernote').summernote({
+  lineHeights: ['0.2', '0.3', '0.4', '0.5', '0.6', '0.8', '1.0', '1.2', '1.4', '1.5', '2.0', '3.0']
+});
+{% endhighlight %}
+
 ### Dialogs
 Dialogs can be placed in `body`, not within Summernote. If you're using Summernote within a modal dialog, please set this option as `true`.
 {% highlight javascript %}


### PR DESCRIPTION
It was a little tricky to figure out how to override the default values for the lineHeight list. 
This sub-section could be very useful and time-saving for other users. 