### PR TITLE
fixed download link

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ bodyClass: page index
   <h1 class="text-center index-title">
     <span class="img-index-title"></span>
     <span class="img-index-title-mobile">Super Simple WYSIWYG<br>Editor on Bootstrap</span>
-    <a href="{{ site.repository }}/archive/master.zip" class="index-download">
+    <a href="{{ site.repository }}/releases/download/v0.8.18/summernote-0.8.18-dist.zip" class="index-download">
       <span class="img-index-download"></span>
     </a>
   </h1>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ bodyClass: page index
   <h1 class="text-center index-title">
     <span class="img-index-title"></span>
     <span class="img-index-title-mobile">Super Simple WYSIWYG<br>Editor on Bootstrap</span>
-    <a href="{{ site.repository }}/releases/download/v0.8.18/summernote-0.8.18-dist.zip" class="index-download">
+    <a href="{{ site.repository }}/releases/download/v{{ site.version }}/summernote-{{ site.version }}-dist.zip" class="index-download">
       <span class="img-index-download"></span>
     </a>
   </h1>


### PR DESCRIPTION
This is to change main dowload link  to  https://github.com/summernote/summernote/releases/download/v0.8.18/summernote-0.8.18-dist.zip